### PR TITLE
Extract drawing logic from the main app

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,12 +8,14 @@
       "name": "draw-freely-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "jest": "^27.5.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-scripts": "5.0.1",
         "socket.io-client": "^4.8.1"
       },
       "devDependencies": {
+        "@types/jest": "^29.5.14",
         "@types/react": "^19.0.3",
         "@types/react-dom": "^19.0.2",
         "typescript": "^3.2.1"
@@ -420,25 +422,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.0"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
-      "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.3"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2001,9 +2003,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -2013,14 +2015,14 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2045,9 +2047,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
-      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
@@ -2689,6 +2691,29 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils/node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
@@ -3651,6 +3676,208 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -5472,9 +5699,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
-      "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "license": "MIT"
     },
     "node_modules/clean-css": {
@@ -6329,9 +6556,9 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -6973,14 +7200,15 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8249,14 +8477,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.2.tgz",
-      "integrity": "sha512-sJe+TQb2vIaIyO783qN6BlMYWMw3WBOHA1Ay2qxsnjuafEOQFJ2JakedOQirT6D5XPRxDvS7AHYyem9fTpb4LQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.3.tgz",
+      "integrity": "sha512-q5YBMeWy6E2Un0nMGWMgI65MAKtaylxfNJGJxpGh45YDciZB4epbWpaAfImil6CPAPTYB4sh0URQNDRIZG5F2w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -11489,9 +11718,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.16",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.16.tgz",
-      "integrity": "sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==",
+      "version": "2.2.19",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.19.tgz",
+      "integrity": "sha512-94bcyI3RsqiZufXjkr3ltkI86iEl+I7uiHVDtcq9wJUTwYQJ5odHDeSzkkrRzi80jJ8MaeZgqKjH1bAWAFw9bA==",
       "license": "MIT"
     },
     "node_modules/object-assign": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "@types/react": "^19.0.3",
         "@types/react-dom": "^19.0.2",
         "socket.io": "^4.8.1",
-        "typescript": "^3.2.1"
+        "typescript": "^5.8.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -16615,16 +16615,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.1.tgz",
-      "integrity": "sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "@types/jest": "^29.5.14",
         "@types/react": "^19.0.3",
         "@types/react-dom": "^19.0.2",
+        "socket.io": "^4.8.1",
         "typescript": "^3.2.1"
       }
     },
@@ -3561,6 +3562,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
@@ -5267,6 +5278,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -6051,6 +6072,20 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -6969,6 +7004,27 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/engine.io": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
     "node_modules/engine.io-client": {
       "version": "6.6.2",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.2.tgz",
@@ -7027,6 +7083,56 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/enhanced-resolve": {
@@ -15042,6 +15148,76 @@
         "node": ">=8"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/socket.io-client": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
@@ -15091,6 +15267,24 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,6 @@
     "@types/react": "^19.0.3",
     "@types/react-dom": "^19.0.2",
     "socket.io": "^4.8.1",
-    "typescript": "^3.2.1"
+    "typescript": "^5.8.2"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "jest": "^27.5.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",
@@ -11,8 +12,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "test": "jest --verbose"
   },
   "browserslist": {
     "production": [
@@ -27,6 +27,7 @@
     ]
   },
   "devDependencies": {
+    "@types/jest": "^29.5.14",
     "@types/react": "^19.0.3",
     "@types/react-dom": "^19.0.2",
     "typescript": "^3.2.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@types/jest": "^29.5.14",
     "@types/react": "^19.0.3",
     "@types/react-dom": "^19.0.2",
+    "socket.io": "^4.8.1",
     "typescript": "^3.2.1"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,365 +1,198 @@
 import React, { useEffect, useRef, useState } from "react"
 import { socket } from "./socket"
-import { distanceBetweenTwoPoints } from "./utils"
+import { GameMode, NO_CANVAS_ERROR, NO_CONTEXT_ERROR, SOCKET_EVENTS_INBOUND, SOCKET_EVENTS_OUTBOUND } from "./utils"
 import "./App.css"
-import { type Pointer } from "./types"
+import useDrawing from "./hooks/useDrawing"
+
 const CANVAS_HEIGHT = 300
 const CANVAS_WIDTH = 300
 
-const NO_CANVAS_ERROR = `You're trying to access the canvas ref but it is null. This generally means that
-- The canvas element hasn't mounted yet.
-- The canvas element has unmounted.
-- The canvas element is conditionally not being loaded at the time.
-- There is a race condition between state updates and ref access. E.g. If you store canvas size in state and resize the canvas but you try to access the ref before the canvas remounts after the state change.
-More details here: https://react.dev/learn/manipulating-the-dom-with-refs#accessing-another-components-dom-nodes`
-const NO_CONTEXT_ERROR = `Canvas context is null. This generally means that
-- The canvas ref is null.
-- The context identifier is not supported by the browser.
-- The canvas has already been set to a different context mode.
-More details here: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext`
-
-const SOCKET_EVENTS_INBOUND = {
-  DRAW: "draw",
-  CONNECT: "connect",
-  INITIAL_DATA: "initial-data",
-  UPDATE_TURN: "update-turn",
-  CLEAR_CANVAS: "clear-canvas",
-  SELECTED_GAME_MODE: "selected-game-mode",
-} as const
-
-const SOCKET_EVENTS_OUTBOUND = {
-  DRAW: "draw",
-  END_TURN: "end-turn",
-  CLEAR_CANVAS: "clear-canvas",
-  SELECT_GAME_MODE: "select-game-mode",
-} as const
-
-enum GameMode {
-  OneLine = "One Line",
-  LineLengthLimit = "Line Length Limit",
-}
-
 const App: React.FC = () => {
-  // I'd typically initialise this as undefined, but using it as a `ref` in the canvas element requires it to be | null.
-  const canvasRef = useRef<HTMLCanvasElement | null>(null)
-  const [isDrawing, setIsDrawing] = useState(false)
-  const [gameMode, setGameMode] = useState<GameMode | undefined | null>(
-    undefined
-  )
-  const [turnPlayer, setTurnPlayer] = useState<string | undefined>(undefined)
-  const contextRef = useRef<CanvasRenderingContext2D>(undefined)
-
-  const [lineLengthLimit, setLineLengthLimit] = useState<number | undefined>(
-    undefined
-  )
-  const [currentLineLength, setCurrentLineLength] = useState<number>(0)
-
-  const [ongoingPointer, setOngoingPointer] = useState<Pointer | undefined | null>(undefined)
-
-  const shouldShowCanvas = gameMode !== undefined && gameMode !== null
-  const isMyTurn = socket.id === turnPlayer
-
-  useEffect(() => {
-    if (!shouldShowCanvas) return
-
-    const canvas = canvasRef.current
-    if (!canvas) {
-      console.error(NO_CANVAS_ERROR)
-      return
-    }
-
-    canvas.width = CANVAS_HEIGHT
-    canvas.height = CANVAS_WIDTH
-
-    const context = canvas.getContext("2d")
-    if (!context) {
-      console.error(NO_CONTEXT_ERROR)
-      return
-    }
-
-    context.lineCap = "round"
-    context.strokeStyle = "black"
-    context.lineWidth = 2
-    contextRef.current = context
-  }, [shouldShowCanvas])
-
-  useEffect(() => {
-    const onDraw = (drawing: Array<number>) => {
-      const context = contextRef.current
-      if (!context) {
-        console.error(NO_CONTEXT_ERROR)
-        return
-      }
-
-      console.log("drawing", drawing)
-      context.putImageData(
-        new ImageData(new Uint8ClampedArray(drawing), 300, 300),
-        0,
-        0
-      )
-    }
-
-    const onInitialLoad = ({
-      drawing,
-      lineLengthLimit: lengthLimit,
-      gameMode: mode,
-    }: {
-      drawing: Array<number>
-      lineLengthLimit: number
-      gameMode: GameMode
-    }) => {
-      console.log({ drawing, lengthLimit, gameMode }, "initial data")
-
-      setLineLengthLimit(150)
-      setGameMode(mode)
-
-      const context = contextRef.current
-      if (!context) {
-        console.error(NO_CONTEXT_ERROR)
-        return
-      }
-
-      context.putImageData(
-        new ImageData(new Uint8ClampedArray(drawing), 300, 300),
-        0,
-        0
-      )
-    }
-
-    const onUpdateTurn = ({ turnPlayer }: { turnPlayer: string }) => {
-      setTurnPlayer(turnPlayer)
-    }
-
-    const clearCanvas = ({ mode }: { mode: GameMode }) => {
-      const canvas = canvasRef.current
-      if (!canvas) {
-        console.error(NO_CANVAS_ERROR)
-        return
-      }
-
-      const context = contextRef.current
-      if (!context) {
-        console.error(NO_CONTEXT_ERROR)
-        return
-      }
-
-      context.clearRect(0, 0, canvas.width, canvas.height)
-
-      setGameMode(mode)
-    }
-
-    const selectedGameMode = (mode: GameMode) => {
-      setGameMode(mode)
-    }
-
-    socket.on(SOCKET_EVENTS_INBOUND.DRAW, onDraw)
-    socket.on(SOCKET_EVENTS_INBOUND.INITIAL_DATA, onInitialLoad)
-    socket.on(SOCKET_EVENTS_INBOUND.UPDATE_TURN, onUpdateTurn)
-    socket.on(SOCKET_EVENTS_INBOUND.CLEAR_CANVAS, clearCanvas)
-    socket.on(SOCKET_EVENTS_INBOUND.SELECTED_GAME_MODE, selectedGameMode)
-
-    return () => {
-      socket.off(SOCKET_EVENTS_INBOUND.DRAW, onDraw)
-      socket.off(SOCKET_EVENTS_INBOUND.INITIAL_DATA, onInitialLoad)
-      socket.off(SOCKET_EVENTS_INBOUND.UPDATE_TURN, onUpdateTurn)
-      socket.off(SOCKET_EVENTS_INBOUND.CLEAR_CANVAS, clearCanvas)
-      socket.off(SOCKET_EVENTS_INBOUND.SELECTED_GAME_MODE, selectedGameMode)
-    }
-  }, [])
-
-  const startDrawing = (event: React.PointerEvent<HTMLCanvasElement>) => {
-    if (!isMyTurn) return
-
-    const { pageX, pageY, pointerId } = event
-    const canvas = canvasRef.current
-    if (!canvas) {
-      console.error(NO_CANVAS_ERROR)
-      return
-    }
-    const rect = canvas.getBoundingClientRect()
-    const relativeX = pageX - rect.left
-    const relativeY = pageY - rect.top
-
-    const context = contextRef.current
-    if (!context) {
-      console.error(NO_CONTEXT_ERROR)
-      return
-    }
-
-    setIsDrawing(true)
-
-    context.beginPath()
-    context.moveTo(relativeX, relativeY)
-    context.lineTo(relativeX, relativeY)
-    context.stroke()
-    setOngoingPointer({
-      [pointerId]: {
-        relativeX,
-        relativeY,
-      },
-    })
-
-    socket?.emit(
-      SOCKET_EVENTS_OUTBOUND.DRAW,
-      context.getImageData(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT).data
-    )
-  }
-
-  const draw = (event: React.PointerEvent<HTMLCanvasElement>) => {
-    if (!isDrawing) return
-
-    const pointer = ongoingPointer?.[event.pointerId]
-    if (!pointer) {
-      console.error(
-        `Could not find pointer for ${event.type} pointer id ${event.pointerId}`
-      )
-      return
-    }
-
-    const context = contextRef.current
-    if (!context) {
-      console.error(NO_CONTEXT_ERROR)
-      return
-    }
-
-    const { pageX, pageY } = event
-    const canvas = canvasRef.current
-    if (!canvas) {
-      console.error(NO_CANVAS_ERROR)
-      return
-    }
-    const rect = canvas.getBoundingClientRect()
-    const relativeX = pageX - rect.left
-    const relativeY = pageY - rect.top
-
-    context.beginPath()
-    context.moveTo(pointer.relativeX, pointer.relativeY)
-    context.lineTo(relativeX, relativeY)
-    context.stroke()
-
-    if (gameMode === GameMode.LineLengthLimit) {
-      if (
-        lineLengthLimit !== undefined &&
-        currentLineLength > lineLengthLimit
-      ) {
-        stopDrawing(event)
-        setCurrentLineLength(0)
-
-        return
-      }
-
-      const additionalLength = distanceBetweenTwoPoints({
-        x1: pointer.relativeX,
-        y1: pointer.relativeY,
-        x2: relativeX,
-        y2: relativeY,
-      })
-
-      setCurrentLineLength((prev) => prev + additionalLength)
-
-      socket?.emit(
-        SOCKET_EVENTS_OUTBOUND.DRAW,
-        context.getImageData(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT).data
-      )
-    } else if (gameMode === GameMode.OneLine) {
-      socket?.emit(
-        SOCKET_EVENTS_OUTBOUND.DRAW,
-        context.getImageData(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT).data
-      )
-    } else {
-      throw Error(`Invalid Game Mode '${gameMode}'`)
-    }
-
-    setOngoingPointer({
-      [event.pointerId]: {
-        relativeX: relativeX,
-        relativeY: relativeY,
-      },
-    })
-  }
-
-  const stopDrawing = (event: React.PointerEvent<HTMLCanvasElement>) => {
-    if (!isDrawing) return
-
-    const pointer = ongoingPointer?.[event.pointerId]
-    if (!pointer) {
-      console.error(
-        `Could not find pointer for ${event.type} pointer id ${event.pointerId}`
-      )
-      return
-    }
-
-    setIsDrawing(false)
-
-    socket.emit(SOCKET_EVENTS_OUTBOUND.END_TURN)
-  }
-
-  const clearCanvas = () => {
-    if (!contextRef.current) return
-
-    contextRef.current.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT)
-
-    socket?.emit(SOCKET_EVENTS_OUTBOUND.CLEAR_CANVAS)
-  }
-
-  const selectGameMode = (mode: GameMode) => {
-    setGameMode(mode)
-
-    socket?.emit(SOCKET_EVENTS_OUTBOUND.SELECT_GAME_MODE, mode)
-  }
-
-  return (
-    <div className="drawing-container">
-      <h1>Draw Freely</h1>
-      {shouldShowCanvas ? (
-        <>
-          <div>You've selected the '{gameMode}' game mode.</div>
-          <div>
-            {isMyTurn
-              ? "It is your turn to draw!"
-              : `Waiting for your turn to draw. It is currently ${turnPlayer}'s turn to draw!`}
-          </div>
-          <canvas
-            ref={canvasRef}
-            onPointerDown={startDrawing}
-            onPointerMove={draw}
-            onPointerUp={stopDrawing}
-            onPointerLeave={stopDrawing}
-            className="drawing-canvas"
-          />
-          <button type="button" onClick={clearCanvas} className="clear-button">
-            Clear Canvas
-          </button>
-        </>
-      ) : (
-        <>
-          {(Object.keys(GameMode) as Array<keyof typeof GameMode>).map(
-            (enumKey) => {
-              return (
-                <button onClick={() => selectGameMode(GameMode[enumKey])}>
-                  {GameMode[enumKey]}
-                </button>
-              )
-            }
-          )}
-        <div className="about-content">
-          <h3>About</h3>
-          <p>
-            Draw Freely is a free online multiplayer drawing game designed to
-            encourage mindfulness and creativity.
-          </p>
-          <p>
-            Choose your game mode and draw something with someone else or just
-            by yourself. You don't compete against each other, you just draw things for fun!
-          </p>
-          <aside>
-            Note, this game is still a work in progress!
-          </aside>
-        </div>
-        </>
-      )}
-    </div>
-  )
+		// I'd typically initialise this as undefined, but using it as a `ref` in the canvas element requires it to be | null.
+		const canvasRef = useRef<HTMLCanvasElement | null>(null)
+		const contextRef = useRef<CanvasRenderingContext2D>(undefined)
+		
+		const [gameMode, setGameMode] = useState<GameMode | undefined | null>(
+				undefined,
+		)
+		const [turnPlayer, setTurnPlayer] = useState<string | undefined>(undefined)
+		const isMyTurn = socket.id === turnPlayer
+		
+		const shouldShowCanvas = gameMode !== undefined && gameMode !== null
+		
+		const canvasDimension = {
+				width: CANVAS_WIDTH,
+				height: CANVAS_HEIGHT,
+		}
+		
+		useEffect(() => {
+				if (!shouldShowCanvas) return
+				
+				const canvas = canvasRef.current
+				if (!canvas) {
+						console.error(NO_CANVAS_ERROR)
+						return
+				}
+				
+				canvas.width = CANVAS_HEIGHT
+				canvas.height = CANVAS_WIDTH
+				
+				const context = canvas.getContext("2d")
+				if (!context) {
+						console.error(NO_CONTEXT_ERROR)
+						return
+				}
+				
+				context.lineCap = "round"
+				context.strokeStyle = "black"
+				context.lineWidth = 2
+				contextRef.current = context
+		}, [shouldShowCanvas])
+		
+		useEffect(() => {
+				const onDraw = (drawing: Array<number>) => {
+						const context = contextRef.current
+						if (!context) {
+								console.error(NO_CONTEXT_ERROR)
+								return
+						}
+						
+						console.log("drawing", drawing)
+						context.putImageData(
+								new ImageData(new Uint8ClampedArray(drawing), 300, 300),
+								0,
+								0,
+						)
+				}
+				
+				const onInitialLoad = ({
+						drawing,
+						lineLengthLimit: lengthLimit,
+						gameMode: mode,
+				}: {
+						drawing: Array<number>
+						lineLengthLimit: number
+						gameMode: GameMode
+				}) => {
+						console.log({ drawing, lengthLimit, gameMode }, "initial data")
+						
+						// setLineLengthLimit(150)
+						setGameMode(mode)
+						
+						const context = contextRef.current
+						if (!context) {
+								console.error(NO_CONTEXT_ERROR)
+								return
+						}
+						
+						context.putImageData(
+								new ImageData(new Uint8ClampedArray(drawing), 300, 300),
+								0,
+								0,
+						)
+				}
+				
+				const onUpdateTurn = ({ turnPlayer }: { turnPlayer: string }) => {
+						setTurnPlayer(turnPlayer)
+				}
+				
+				const clearCanvas = ({ mode }: { mode: GameMode }) => {
+						const canvas = canvasRef.current
+						if (!canvas) {
+								console.error(NO_CANVAS_ERROR)
+								return
+						}
+						
+						const context = contextRef.current
+						if (!context) {
+								console.error(NO_CONTEXT_ERROR)
+								return
+						}
+						
+						context.clearRect(0, 0, canvas.width, canvas.height)
+						
+						setGameMode(mode)
+				}
+				
+				const selectedGameMode = (mode: GameMode) => {
+						setGameMode(mode)
+				}
+				
+				socket.on(SOCKET_EVENTS_INBOUND.DRAW, onDraw)
+				socket.on(SOCKET_EVENTS_INBOUND.INITIAL_DATA, onInitialLoad)
+				socket.on(SOCKET_EVENTS_INBOUND.UPDATE_TURN, onUpdateTurn)
+				socket.on(SOCKET_EVENTS_INBOUND.CLEAR_CANVAS, clearCanvas)
+				socket.on(SOCKET_EVENTS_INBOUND.SELECTED_GAME_MODE, selectedGameMode)
+				
+				return () => {
+						socket.off(SOCKET_EVENTS_INBOUND.DRAW, onDraw)
+						socket.off(SOCKET_EVENTS_INBOUND.INITIAL_DATA, onInitialLoad)
+						socket.off(SOCKET_EVENTS_INBOUND.UPDATE_TURN, onUpdateTurn)
+						socket.off(SOCKET_EVENTS_INBOUND.CLEAR_CANVAS, clearCanvas)
+						socket.off(SOCKET_EVENTS_INBOUND.SELECTED_GAME_MODE, selectedGameMode)
+				}
+		}, [])
+		
+		const { startDrawing, draw, stopDrawing, clearCanvas } = useDrawing({ canvasRef, canvasDimension, contextRef, gameMode, turnPlayer })
+		
+		const selectGameMode = (mode: GameMode) => {
+				setGameMode(mode)
+				
+				socket?.emit(SOCKET_EVENTS_OUTBOUND.SELECT_GAME_MODE, mode)
+		}
+		
+		return (
+				<div className="drawing-container">
+						<h1>Draw Freely</h1>
+						{shouldShowCanvas ? (
+								<>
+										<div>You've selected the '{gameMode}' game mode.</div>
+										<div>
+												{isMyTurn
+														? "It is your turn to draw!"
+														: `Waiting for your turn to draw. It is currently ${turnPlayer}'s turn to draw!`}
+										</div>
+										<canvas
+												ref={canvasRef}
+												onPointerDown={startDrawing}
+												onPointerMove={draw}
+												onPointerUp={stopDrawing}
+												onPointerLeave={stopDrawing}
+												className="drawing-canvas"
+										/>
+										<button type="button" onClick={clearCanvas} className="clear-button">
+												Clear Canvas
+										</button>
+								</>
+						) : (
+								<>
+										{( Object.keys(GameMode) as Array<keyof typeof GameMode> ).map(
+												(enumKey) => {
+														return (
+																<button onClick={() => selectGameMode(GameMode[enumKey])}>
+																		{GameMode[enumKey]}
+																</button>
+														)
+												},
+										)}
+										<div className="about-content">
+												<h3>About</h3>
+												<p>
+														Draw Freely is a free online multiplayer drawing game designed to
+														encourage mindfulness and creativity.
+												</p>
+												<p>
+														Choose your game mode and draw something with someone else or just
+														by yourself. You don't compete against each other, you just draw things for fun!
+												</p>
+												<aside>
+														Note, this game is still a work in progress!
+												</aside>
+										</div>
+								</>
+						)}
+				</div>
+		)
 }
 
 export default App

--- a/frontend/src/hooks/useDrawing.ts
+++ b/frontend/src/hooks/useDrawing.ts
@@ -1,0 +1,170 @@
+import React, { RefObject, useState } from "react"
+import type { Pointer } from "@/types"
+import { socket } from "../socket"
+import { distanceBetweenTwoPoints, GameMode, NO_CANVAS_ERROR, NO_CONTEXT_ERROR, SOCKET_EVENTS_OUTBOUND } from "../utils"
+
+interface DrawingHookProps {
+		canvasRef: RefObject<HTMLCanvasElement | null>
+		canvasDimension: {
+				width: number
+				height: number
+		}
+		contextRef: RefObject<CanvasRenderingContext2D | undefined>
+		gameMode: GameMode | undefined | null
+		turnPlayer: string | undefined
+}
+
+function useDrawing({ canvasRef, canvasDimension, contextRef, gameMode, turnPlayer }: DrawingHookProps) {
+		const [isDrawing, setIsDrawing] = useState(false)
+		const [lineLengthLimit, setLineLengthLimit] = useState<number | undefined>(undefined)
+		const [currentLineLength, setCurrentLineLength] = useState<number>(0)
+		const [ongoingPointer, setOngoingPointer] = useState<Pointer | undefined | null>(undefined)
+		const isMyTurn = socket.id === turnPlayer
+		
+		const startDrawing = (event: React.PointerEvent<HTMLCanvasElement>) => {
+				if (!isMyTurn) return
+				
+				const { pageX, pageY, pointerId } = event
+				const canvas = canvasRef.current
+				if (!canvas) {
+						console.error(NO_CANVAS_ERROR)
+						return
+				}
+				const rect = canvas.getBoundingClientRect()
+				const relativeX = pageX - rect.left
+				const relativeY = pageY - rect.top
+				
+				const context = contextRef.current
+				if (!context) {
+						console.error(NO_CONTEXT_ERROR)
+						return
+				}
+				
+				setIsDrawing(true)
+				
+				context.beginPath()
+				context.moveTo(relativeX, relativeY)
+				context.lineTo(relativeX, relativeY)
+				context.stroke()
+				setOngoingPointer({
+						[pointerId]: {
+								relativeX,
+								relativeY,
+						},
+				})
+				
+				socket?.emit(
+						SOCKET_EVENTS_OUTBOUND.DRAW,
+						context.getImageData(0, 0, canvasDimension.width, canvasDimension.height).data,
+				)
+		}
+		
+		const draw = (event: React.PointerEvent<HTMLCanvasElement>) => {
+				if (!isDrawing) return
+				
+				const pointer = ongoingPointer?.[event.pointerId]
+				if (!pointer) {
+						console.error(
+								`Could not find pointer for ${event.type} pointer id ${event.pointerId}`,
+						)
+						return
+				}
+				
+				const context = contextRef!.current
+				if (!context) {
+						console.error(NO_CONTEXT_ERROR)
+						return
+				}
+				
+				const { pageX, pageY } = event
+				const canvas = canvasRef!.current
+				if (!canvas) {
+						console.error(NO_CANVAS_ERROR)
+						return
+				}
+				const rect = canvas.getBoundingClientRect()
+				const relativeX = pageX - rect.left
+				const relativeY = pageY - rect.top
+				
+				context.beginPath()
+				context.moveTo(pointer.relativeX, pointer.relativeY)
+				context.lineTo(relativeX, relativeY)
+				context.stroke()
+				
+				if (gameMode === GameMode.LineLengthLimit) {
+						if (
+								lineLengthLimit !== undefined &&
+								currentLineLength > lineLengthLimit
+						) {
+								stopDrawing(event)
+								setCurrentLineLength(0)
+								
+								return
+						}
+						
+						const additionalLength = distanceBetweenTwoPoints({
+								x1: pointer.relativeX,
+								y1: pointer.relativeY,
+								x2: relativeX,
+								y2: relativeY,
+						})
+						
+						setCurrentLineLength((prev) => prev + additionalLength)
+						
+						socket?.emit(
+								SOCKET_EVENTS_OUTBOUND.DRAW,
+								context.getImageData(0, 0, canvasDimension.width, canvasDimension.height).data,
+						)
+				}
+				else if (gameMode === GameMode.OneLine) {
+						socket?.emit(
+								SOCKET_EVENTS_OUTBOUND.DRAW,
+								context.getImageData(0, 0, canvasDimension.width, canvasDimension.height).data,
+						)
+				}
+				else {
+						throw Error(`Invalid Game Mode '${gameMode}'`)
+				}
+				
+				setOngoingPointer({
+						[event.pointerId]: {
+								relativeX: relativeX,
+								relativeY: relativeY,
+						},
+				})
+		}
+		
+		const stopDrawing = (event: React.PointerEvent<HTMLCanvasElement>) => {
+				if (!isDrawing) return
+				
+				const pointer = ongoingPointer?.[event.pointerId]
+				if (!pointer) {
+						console.error(
+								`Could not find pointer for ${event.type} pointer id ${event.pointerId}`,
+						)
+						return
+				}
+				
+				setIsDrawing(false)
+				
+				socket.emit(SOCKET_EVENTS_OUTBOUND.END_TURN)
+		}
+		
+		const clearCanvas = () => {
+				if (!contextRef.current) return
+				
+				contextRef.current.clearRect(0, 0, canvasDimension.width, canvasDimension.height)
+				
+				socket?.emit(SOCKET_EVENTS_OUTBOUND.CLEAR_CANVAS)
+		}
+		
+		return {
+				startDrawing,
+				draw,
+				stopDrawing,
+				clearCanvas,
+				setLineLengthLimit
+		}
+}
+
+export default useDrawing

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,14 +1,49 @@
 // Pythagoras' theorem
 export function distanceBetweenTwoPoints({
-    x1,
-    y1,
-    x2,
-    y2,
+		x1,
+		y1,
+		x2,
+		y2,
 }: {
-    x1: number
-    y1: number
-    x2: number
-    y2: number
+		x1: number
+		y1: number
+		x2: number
+		y2: number
 }): number {
-    return Math.hypot(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2))
+		return Math.hypot(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2))
 }
+
+const NO_CANVAS_ERROR = `You're trying to access the canvas ref but it is null. This generally means that
+- The canvas element hasn't mounted yet.
+- The canvas element has unmounted.
+- The canvas element is conditionally not being loaded at the time.
+- There is a race condition between state updates and ref access. E.g. If you store canvas size in state and resize the canvas but you try to access the ref before the canvas remounts after the state change.
+More details here: https://react.dev/learn/manipulating-the-dom-with-refs#accessing-another-components-dom-nodes`
+const NO_CONTEXT_ERROR = `Canvas context is null. This generally means that
+- The canvas ref is null.
+- The context identifier is not supported by the browser.
+- The canvas has already been set to a different context mode.
+More details here: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext`
+
+const SOCKET_EVENTS_INBOUND = {
+		DRAW: "draw",
+		CONNECT: "connect",
+		INITIAL_DATA: "initial-data",
+		UPDATE_TURN: "update-turn",
+		CLEAR_CANVAS: "clear-canvas",
+		SELECTED_GAME_MODE: "selected-game-mode",
+} as const
+
+const SOCKET_EVENTS_OUTBOUND = {
+		DRAW: "draw",
+		END_TURN: "end-turn",
+		CLEAR_CANVAS: "clear-canvas",
+		SELECT_GAME_MODE: "select-game-mode",
+} as const
+
+enum GameMode {
+		OneLine         = "One Line",
+		LineLengthLimit = "Line Length Limit",
+}
+
+export { NO_CANVAS_ERROR, NO_CONTEXT_ERROR, SOCKET_EVENTS_INBOUND, SOCKET_EVENTS_OUTBOUND, GameMode }


### PR DESCRIPTION
Logic of the drawing and UI are written in the same file (`App.tsx`), making it harder to reuse and test.

- Separate the drawing logic from the main file via creating a custom hook `useDrawing`
- The `useDrawing` hook should have the required inputs, and return all the drawing functions and the states

### Input needed
- `canvasRef`: Access to the canvas element
- `contextRef`: Access to the context after the canvas is initialised
- `gameMode`: `OneLine` and `LineLengthLimit` for different drawing rules
- `turnPlayer`

### Functions to return
- `startDrawing`
- `draw`
- `stopDrawing`
- `clearCanvas`
- `updateDrawingContext`

### States managed
- `isDrawing`
- `isMyTurn`: if `turnPlayer` matches `socket.id` then return true
- `ongoingPointer`
- `currentLineLength`
- `lineLengthLimit`

## Next Step
- Add a 10-second timer for each turn (#16)